### PR TITLE
Replace legacy hosting references

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ rentalcore:
 
 ---
 
-[📦 Monorepo auf GitHub](https://github.com/nbt4/cores) | `nobentie/rentalcore:latest`
+[Quellcode](https://github.com/nbt4/rentalcore) | [Monorepo](https://github.com/nbt4/cores) | `nobentie/rentalcore:latest`

--- a/docs/ACCESSORIES_CONSUMABLES_IMPLEMENTATION_GUIDE.md
+++ b/docs/ACCESSORIES_CONSUMABLES_IMPLEMENTATION_GUIDE.md
@@ -21,7 +21,7 @@
 - ✅ API documentation created
 
 #### Git & Deployment
-- ✅ Committed to GitLab (commit: 44e9670)
+- ✅ Committed to GitHub (commit: 44e9670)
 - ✅ Pushed to origin/main
 - ⏳ Docker image building (version 4.1.36)
 

--- a/docs/FRONTEND_STATUS.md
+++ b/docs/FRONTEND_STATUS.md
@@ -281,7 +281,7 @@ All tables and views exist and are functional:
 - ✅ Docker image built successfully
 
 **Git Status**:
-- ✅ All changes committed to GitLab
+- ✅ All changes committed to GitHub
 - ✅ Docker image pushed to Docker Hub: `nobentie/rentalcore:4.1.36`
 
 ---
@@ -393,4 +393,4 @@ For questions or issues:
 
 **Last Updated**: 2025-11-24
 **Version**: 4.1.36
-**Issue**: GitLab #37
+**Issue**: legacy tracker issue #37

--- a/docs/superpowers/plans/2026-04-10-pdf-mapping-workflow.md
+++ b/docs/superpowers/plans/2026-04-10-pdf-mapping-workflow.md
@@ -1314,7 +1314,7 @@ docker tag nobentie/rentalcore:5.X.Y nobentie/rentalcore:latest
 docker push nobentie/rentalcore:latest
 ```
 
-- [ ] **Step 5: Push to GitLab**
+- [ ] **Step 5: Push to GitHub**
 
 ```bash
 cd /opt/dev/cores/rentalcore && git push origin main

--- a/docs/superpowers/plans/2026-04-12-two-stage-device-availability.md
+++ b/docs/superpowers/plans/2026-04-12-two-stage-device-availability.md
@@ -1011,7 +1011,7 @@ In `README.md`, find the version history section. Add at the top:
 ### **v5.3.28** - Feature: two-stage device availability — job form saves requirements, job detail assigns specific devices
 ```
 
-- [ ] **Step 3: Git push to GitLab**
+- [ ] **Step 3: Git push to GitHub**
 
 ```bash
 cd /opt/dev/cores/rentalcore

--- a/docs/superpowers/plans/2026-05-07-ocr-job-positions-device-swap.md
+++ b/docs/superpowers/plans/2026-05-07-ocr-job-positions-device-swap.md
@@ -665,7 +665,7 @@ In `README.md` neuen Eintrag unter der aktuellen Version hinzufügen (Version au
 - Start/End-Datum im OCR Mapping-Modal editierbar
 ```
 
-- [ ] **Schritt 3: GitLab pushen**
+- [ ] **Schritt 3: GitHub pushen**
 
 ```bash
 cd /opt/dev/cores/rentalcore
@@ -849,7 +849,7 @@ Notiere aktuelle Version und erhöhe Patch um 1.
 - ScanResponse enthält swapped/swapped_from Felder zur UI-Rückmeldung
 ```
 
-- [ ] **Schritt 3: GitLab pushen**
+- [ ] **Schritt 3: GitHub pushen**
 
 ```bash
 cd /opt/dev/cores/warehousecore


### PR DESCRIPTION
Moves README and historical documentation references from the retired hosting workflow to GitHub.

Checks:
- `git diff --check`
- workspace legacy-host and token scan