### PR TITLE
fix: disable profile settings routes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1332,8 +1332,6 @@ func setupRoutes(r *gin.Engine,
 		// Profile Settings routes (moved to end to avoid potential conflicts)
 		profile := protected.Group("/profile")
 		{
-			profile.GET("/settings", profileHandler.ProfileSettingsForm)
-			profile.POST("/settings", profileHandler.UpdateProfileSettings)
 			profile.GET("/security-status", profileHandler.SecurityStatus)
 
 			// WebAuthn (Passkey) routes


### PR DESCRIPTION
Disables the legacy profile settings GET/POST routes so RentalCore cannot edit user profile data. Profile management remains centralized in Cores Dashboard; logout remains available in RentalCore.

Checks:
- `git diff --check`