### PR TITLE
fix: remove profile navigation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { Layout } from './components/Layout';
@@ -18,6 +18,8 @@ function App() {
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route path="/profile" element={<Navigate to="/" replace />} />
+          <Route path="/profile/settings" element={<Navigate to="/" replace />} />
           <Route path="/change-password" element={
             <ProtectedRoute bypassForcePasswordChange><ChangePassword /></ProtectedRoute>
           } />

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -152,10 +152,6 @@
 
             <!-- User Settings Dropdown -->
             <div class="rc-user-menu">
-                <a href="/profile/settings" class="rc-user-menu-item" title="Profile Settings">
-                    <i class="bi bi-person-gear"></i>
-                    <span class="rc-nav-label" data-i18n="settings.profile">Profile</span>
-                </a>
                 <a href="/settings/company" class="rc-user-menu-item" title="Company Settings">
                     <i class="bi bi-building-gear"></i>
                     <span class="rc-nav-label" data-i18n="settings.company">Company</span>

--- a/web/templates/navbar.html
+++ b/web/templates/navbar.html
@@ -127,10 +127,6 @@
 
             <!-- User Dropdown Menu -->
             <div class="rc-user-dropdown-menu" id="userDropdownMenu">
-                <a href="/profile/settings" class="rc-user-dropdown-item {{if or (eq .currentPage "profile") (eq .currentPage "profile-settings")}}active{{end}}">
-                    <i class="bi bi-person-gear"></i>
-                    <span class="rc-nav-label">Profile Settings</span>
-                </a>
                 <a href="/settings/company" class="rc-user-dropdown-item {{if eq .currentPage "settings"}}active{{end}}">
                     <i class="bi bi-building-gear"></i>
                     <span class="rc-nav-label">Company Settings</span>


### PR DESCRIPTION
Removes remaining legacy template profile links and redirects the React `/profile` routes to the service dashboard, so the username cannot open an editable profile page.

Checks:
- `git diff --check`